### PR TITLE
fix: patch tooltip components instead of replacing all

### DIFF
--- a/Common/src/main/java/fuzs/easyanvils/client/handler/NameTagTooltipHandler.java
+++ b/Common/src/main/java/fuzs/easyanvils/client/handler/NameTagTooltipHandler.java
@@ -31,7 +31,8 @@ public class NameTagTooltipHandler {
                     .withStyle(ChatFormatting.GRAY);
             List<Component> components = Proxy.INSTANCE.splitTooltipLines(component);
             if (tooltipFlag.isAdvanced()) {
-                lines.addAll(lines.size() - (!itemStack.getComponents().isEmpty() ? 2 : 1), components);
+                int offset = itemStack.getComponentsPatch().isEmpty() ? 1 : 2;
+                lines.addAll(lines.size() - offset, components);
             } else {
                 lines.addAll(components);
             }


### PR DESCRIPTION
This PR closes issue 138: https://github.com/Fuzss/easy-anvils/issues/138

When advanced tooltips are shown, the getComponents call was overriding all the fields on the Name Tag tooltip. using getComponentsPatch selectively updates a portion of the tooltip, without reordering the components.